### PR TITLE
Add folder and exclude parameters to readme_translator.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ readmeai_auto を始める前に、実行時環境が次の要件を満たして
 ❯ echo 'INSERT-RUN-COMMAND-HERE'
 ```
 
+#### フォルダの指定
+`--folder` パラメータを使用して、翻訳対象のフォルダを指定できます。
+```sh
+❯ python readme_translator.py --folder <フォルダパス>
+```
+
+#### 除外ファイル/フォルダの指定
+`--exclude` パラメータを使用して、翻訳から除外するファイルまたはフォルダを指定できます。
+```sh
+❯ python readme_translator.py --exclude <ファイル/フォルダパス>
+```
+
 ### テスト
 次のコマンドを使用してテストスイートを実行します。
 **`pip` を使用** &nbsp; [<img align="center" src="" />]()


### PR DESCRIPTION
Add support for specifying arbitrary folders and excluding specific files or folders in the `readme_translator.py` script.

* **readme_translator.py**
  - Add `--folder` parameter to specify the target folder for translation.
  - Add `--exclude` parameter to specify files or folders to exclude from translation.
  - Update `translate_readme` method to handle `--folder` and `--exclude` parameters.
  - Modify file reading logic to recursively read files from the specified folder.
  - Implement exclusion logic to skip specified files or folders during translation.

* **README.md**
  - Add instructions for using the new `--folder` and `--exclude` parameters.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/readmeai_auto/pull/1?shareId=b7c81676-6a10-4697-aab6-b262ea271f88).